### PR TITLE
[bug] Fix utils depth2img by importing cv2 and numpy

### DIFF
--- a/modules/utils.py
+++ b/modules/utils.py
@@ -1,6 +1,8 @@
 import taichi as ti
 import torch
 from taichi.math import uvec3
+import numpy as np
+import cv2
 
 taichi_block_size = 128
 


### PR DESCRIPTION
When training without parameter "--no_save_test", there is an error in calling "[depth2img](https://github.com/taichi-dev/taichi-nerfs/blob/b7c617aa284bf0485944e3e6540daadd6b7c5a4c/modules/utils.py#L219)" function in ./modules/utils.py, because cv2 and numpy are not imported.